### PR TITLE
Add /keyEvent endpoint and fix SNAPSHOT dependency resolution

### DIFF
--- a/driver-plugin/src/main/kotlin/io/github/jdemeulenaere/compose/driver/plugin/DriverSettingsPlugin.kt
+++ b/driver-plugin/src/main/kotlin/io/github/jdemeulenaere/compose/driver/plugin/DriverSettingsPlugin.kt
@@ -141,11 +141,7 @@ private fun addDependencies(
 private const val COMPOSABLE_PROPERTY = "compose.driver.composable"
 
 private fun driverDependency(version: String): String {
-    return if (version.endsWith("-SNAPSHOT")) {
-        "project(\":compose-driver:driver-core\")"
-    } else {
-        "\"io.github.jdemeulenaere:compose-driver:$version\""
-    }
+    return "\"io.github.jdemeulenaere:compose-driver:$version\""
 }
 
 private fun androidBuildFile(


### PR DESCRIPTION
> [!IMPORTANT]
> This is part of a stacked PR chain. Please review and merge in order:
> 1. **#2** (this PR) — `/keyEvent` endpoint
> 2. #3 — Multi-root node handling
> 3. #4 — Video recording

## Summary

- **Add `/keyEvent` endpoint** for sending raw keyboard events to Compose UI nodes via `performKeyInput`. This enables testing keyboard-driven interactions that `textInput` alone can't cover — arrow keys, Enter, Escape, modifier keys, function keys, etc.
- **Add `modifiers` parameter** to `/keyEvent` for atomic modifier+key combos (e.g. Ctrl+C, Shift+A, Ctrl+Shift+Delete) in a single request, using `withKeysDown` under the hood.
- **Fix `driverDependency()` in `DriverSettingsPlugin`** to always use Maven coordinates instead of `project(":compose-driver:driver-core")` for SNAPSHOT versions. The project path only resolves within the compose-driver build itself and fails when the plugin is consumed from an external project via Maven Local.

Fixes #1 

## `/keyEvent` endpoint details

**Parameters:**
- `key` (required): property name from `androidx.compose.ui.input.key.Key` (e.g. `A`, `Enter`, `DirectionUp`, `ShiftLeft`, `F1`)
- `action` (optional, default `press`): `press` (key down + up), `down`, or `up`
- `modifiers` (optional): comma-separated list of modifier key names to hold during a `press` action (e.g. `ShiftLeft`, `CtrlLeft,ShiftLeft`). Only applies when `action=press`.
- Standard node-targeting params (`nodeTag`, `nodeText`, etc.)

**Examples:**
```
GET /keyEvent?key=Enter
GET /keyEvent?key=A&nodeTag=myTextField
GET /keyEvent?key=A&modifiers=ShiftLeft
GET /keyEvent?key=C&modifiers=CtrlLeft
GET /keyEvent?key=Delete&modifiers=CtrlLeft,ShiftLeft
GET /keyEvent?key=ShiftLeft&action=down
GET /keyEvent?key=DirectionUp&action=press
```

Key names are resolved via reflection on `Key.Companion`, accounting for the JVM name mangling of inline value class getters (hash suffix after a `-` separator).

## Test plan

- [x] Compiled successfully on both JVM and Android targets
- [x] Published to Maven Local and tested end-to-end from an external Compose project
- [x] Verified key events are dispatched correctly to Compose UI nodes
- [x] Unit tests for key press/down/up mechanics, modifier propagation, and `keyByName` resolution
- [x] Updated sample SKILL.md with `/keyEvent` documentation and keyboard shortcut scenario