### PR TITLE
Handle multiple semantic root nodes (popups)

### DIFF
--- a/driver-core/build.gradle.kts
+++ b/driver-core/build.gradle.kts
@@ -29,6 +29,13 @@ kotlin {
                 implementation(libs.ktor.server.status.pages)
             }
         }
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(compose.foundation)
+                runtimeOnly(compose.desktop.currentOs)
+            }
+        }
     }
 }
 

--- a/driver-core/src/commonMain/kotlin/io/github/jdemeulenaere/compose/driver/ComposeDriver.kt
+++ b/driver-core/src/commonMain/kotlin/io/github/jdemeulenaere/compose/driver/ComposeDriver.kt
@@ -18,9 +18,8 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.isRoot as isRootMatcher
 import androidx.compose.ui.test.longClick
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performScrollTo
@@ -182,12 +181,24 @@ private fun Application.configureDriverModule(
             }
         }
         get("/printTree") {
-            onNode(autoRespondOkOrGif = false) { call.respondText(it.printToString()) }
+            val matcher = call.node()
+            if (matcher != null) {
+                onNode(autoRespondOkOrGif = false) { call.respondText(it.printToString()) }
+            } else {
+                // Print all root nodes (handles popups which create additional roots).
+                withContext(runTestContext) {
+                    test.waitForIdle()
+                    val allRoots = test.onAllNodes(isRootMatcher())
+                    call.respondText(allRoots.printToString(maxDepth = Int.MAX_VALUE))
+                    test.waitForIdle()
+                }
+            }
         }
         get("/waitForIdle") { onNode {} }
         get("/waitForNode") {
             val timeout = call.optionalParam("timeout")?.toLong() ?: 5_000L
-            onNode { waitUntilAtLeastOneExists(call.node(), timeout) }
+            val matcher = call.node() ?: isRootMatcher()
+            onNode { waitUntilAtLeastOneExists(matcher, timeout) }
         }
         get("/click") { onNode { it.performClick() } }
         get("/longClick") { onNode { it.performTouchInput { longClick() } } }
@@ -248,7 +259,11 @@ private suspend fun RoutingContext.ok() {
     call.respondText("ok")
 }
 
-private fun ApplicationCall.node(): SemanticsMatcher {
+/**
+ * Builds a [SemanticsMatcher] from the node-selection query parameters (`nodeTag`, `nodeText`,
+ * etc.). Returns `null` when no selector is provided, meaning "target the root(s)".
+ */
+private fun ApplicationCall.node(): SemanticsMatcher? {
     val nodeTag = optionalParam("nodeTag")
     val nodeText = optionalParam("nodeText")
     val nodeTextSubstring = optionalParam("nodeTextSubstring")?.toBoolean() ?: false
@@ -264,7 +279,7 @@ private fun ApplicationCall.node(): SemanticsMatcher {
         tagMatcher != null && textMatcher != null -> tagMatcher and textMatcher
         tagMatcher != null -> tagMatcher
         textMatcher != null -> textMatcher
-        else -> isRoot()
+        else -> null
     }
 }
 
@@ -312,9 +327,10 @@ private suspend fun RoutingContext.onNode(
     f: suspend ComposeUiTest.(SemanticsNodeInteraction) -> Unit,
 ) {
     val gifDurationMs = call.optionalParam("gifDurationMs")?.toInt()
+    val matcher = call.node()
 
     if (gifDurationMs == null || !autoRespondOkOrGif) {
-        test.f(test.onNode(call.node()))
+        test.f(test.resolveNode(matcher))
         if (autoRespondOkOrGif) ok()
         return
     }
@@ -322,26 +338,36 @@ private suspend fun RoutingContext.onNode(
     require(gifDurationMs in 0..5_000) { "gifDurationMs should be <= 5_000 and >= 0" }
 
     val timeBetweenFramesMs = 16L
-    val frames = generateFrames(test, gifDurationMs, timeBetweenFramesMs, f)
+    val frames = generateFrames(test, gifDurationMs, timeBetweenFramesMs, matcher, f)
     respondGif(frames, timeBetweenFramesMs)
+}
+
+/**
+ * Resolves a single [SemanticsNodeInteraction]. When [matcher] is non-null, uses
+ * [ComposeUiTest.onNode] (which searches across all roots). When [matcher] is null (no selector
+ * provided), targets the first root — safe even when popups add extra roots.
+ */
+private fun ComposeUiTest.resolveNode(matcher: SemanticsMatcher?): SemanticsNodeInteraction {
+    return if (matcher != null) onNode(matcher) else onAllNodes(isRootMatcher())[0]
 }
 
 private suspend fun RoutingContext.generateFrames(
     test: ComposeUiTest,
     gifDurationMs: Int,
     timeBetweenFrames: Long,
+    matcher: SemanticsMatcher?,
     f: suspend ComposeUiTest.(SemanticsNodeInteraction) -> Unit,
 ): List<ImageBitmap> {
     val frames = mutableListOf<ImageBitmap>()
 
     fun screenshotFrame() {
         test.waitForIdle()
-        frames += test.onRoot().captureToImage()
+        frames += test.resolveNode(null).captureToImage()
     }
 
     try {
         test.mainClock.autoAdvance = false
-        test.f(test.onNode(call.node()))
+        test.f(test.resolveNode(matcher))
 
         var t = 0L
         while (t <= gifDurationMs) {

--- a/driver-core/src/jvmTest/kotlin/io/github/jdemeulenaere/compose/driver/KeyEventTest.kt
+++ b/driver-core/src/jvmTest/kotlin/io/github/jdemeulenaere/compose/driver/KeyEventTest.kt
@@ -1,0 +1,206 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package io.github.jdemeulenaere.compose.driver
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.test.withKeysDown
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Tests for key event dispatching, including modifier key support. */
+class KeyEventTest {
+
+    @Test
+    fun pressKey_sendsDownAndUpEvents() {
+        val events = runWithKeyRecorder { node ->
+            node.performKeyInput { pressKey(Key.A) }
+        }
+
+        val downEvents = events.filter { it.type == KeyEventType.KeyDown }
+        val upEvents = events.filter { it.type == KeyEventType.KeyUp }
+        assertEquals(1, downEvents.size, "Expected 1 KeyDown event")
+        assertEquals(1, upEvents.size, "Expected 1 KeyUp event")
+        assertEquals(Key.A, downEvents[0].key)
+        assertEquals(Key.A, upEvents[0].key)
+    }
+
+    @Test
+    fun keyDown_sendsOnlyDownEvent() {
+        val events = runWithKeyRecorder { node ->
+            node.performKeyInput { keyDown(Key.Enter) }
+        }
+
+        assertTrue(events.all { it.type == KeyEventType.KeyDown }, "Expected only KeyDown events")
+        assertEquals(Key.Enter, events.first().key)
+    }
+
+    @Test
+    fun keyUp_sendsOnlyUpEvent() {
+        val events = runWithKeyRecorder { node ->
+            node.performKeyInput {
+                keyDown(Key.Enter)
+                keyUp(Key.Enter)
+            }
+        }
+
+        val upEvents = events.filter { it.type == KeyEventType.KeyUp }
+        assertEquals(1, upEvents.size)
+        assertEquals(Key.Enter, upEvents[0].key)
+    }
+
+    @Test
+    fun pressKey_withShiftModifier_reportsShiftPressed() {
+        val events = runWithKeyRecorder { node ->
+            node.performKeyInput {
+                withKeysDown(listOf(Key.ShiftLeft)) { pressKey(Key.A) }
+            }
+        }
+
+        // Find the KeyDown for A (not for the modifier itself)
+        val keyADown = events.first { it.type == KeyEventType.KeyDown && it.key == Key.A }
+        assertTrue(keyADown.isShiftPressed, "Shift should be reported as pressed during Key.A down")
+    }
+
+    @Test
+    fun pressKey_withCtrlModifier_reportsCtrlPressed() {
+        val events = runWithKeyRecorder { node ->
+            node.performKeyInput {
+                withKeysDown(listOf(Key.CtrlLeft)) { pressKey(Key.C) }
+            }
+        }
+
+        val keyCDown = events.first { it.type == KeyEventType.KeyDown && it.key == Key.C }
+        assertTrue(keyCDown.isCtrlPressed, "Ctrl should be reported as pressed during Key.C down")
+    }
+
+    @Test
+    fun pressKey_withMultipleModifiers_reportsAllModifiersPressed() {
+        val events = runWithKeyRecorder { node ->
+            node.performKeyInput {
+                withKeysDown(listOf(Key.CtrlLeft, Key.ShiftLeft)) { pressKey(Key.Delete) }
+            }
+        }
+
+        val deleteDown =
+            events.first { it.type == KeyEventType.KeyDown && it.key == Key.Delete }
+        assertTrue(deleteDown.isCtrlPressed, "Ctrl should be pressed")
+        assertTrue(deleteDown.isShiftPressed, "Shift should be pressed")
+    }
+
+    @Test
+    fun pressKey_withoutModifiers_reportsNoModifiersPressed() {
+        val events = runWithKeyRecorder { node ->
+            node.performKeyInput { pressKey(Key.A) }
+        }
+
+        val keyADown = events.first { it.type == KeyEventType.KeyDown && it.key == Key.A }
+        assertTrue(!keyADown.isShiftPressed, "Shift should not be pressed")
+        assertTrue(!keyADown.isCtrlPressed, "Ctrl should not be pressed")
+        assertTrue(!keyADown.isAltPressed, "Alt should not be pressed")
+        assertTrue(!keyADown.isMetaPressed, "Meta should not be pressed")
+    }
+
+    @Test
+    fun keyByName_resolvesLetterKeys() {
+        val key = keyByName("A")
+        assertEquals(Key.A, key)
+    }
+
+    @Test
+    fun keyByName_resolvesSpecialKeys() {
+        assertEquals(Key.Enter, keyByName("Enter"))
+        assertEquals(Key.Escape, keyByName("Escape"))
+        assertEquals(Key.Backspace, keyByName("Backspace"))
+        assertEquals(Key.Tab, keyByName("Tab"))
+        assertEquals(Key.Spacebar, keyByName("Spacebar"))
+    }
+
+    @Test
+    fun keyByName_resolvesDirectionKeys() {
+        assertEquals(Key.DirectionUp, keyByName("DirectionUp"))
+        assertEquals(Key.DirectionDown, keyByName("DirectionDown"))
+        assertEquals(Key.DirectionLeft, keyByName("DirectionLeft"))
+        assertEquals(Key.DirectionRight, keyByName("DirectionRight"))
+    }
+
+    @Test
+    fun keyByName_resolvesModifierKeys() {
+        assertEquals(Key.ShiftLeft, keyByName("ShiftLeft"))
+        assertEquals(Key.ShiftRight, keyByName("ShiftRight"))
+        assertEquals(Key.CtrlLeft, keyByName("CtrlLeft"))
+        assertEquals(Key.CtrlRight, keyByName("CtrlRight"))
+        assertEquals(Key.AltLeft, keyByName("AltLeft"))
+        assertEquals(Key.MetaLeft, keyByName("MetaLeft"))
+    }
+
+    @Test
+    fun keyByName_resolvesFunctionKeys() {
+        assertEquals(Key.F1, keyByName("F1"))
+        assertEquals(Key.F12, keyByName("F12"))
+    }
+
+    @Test
+    fun keyByName_throwsForUnknownKey() {
+        try {
+            keyByName("NonExistentKey")
+            throw AssertionError("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("Unknown key"))
+        }
+    }
+
+    /**
+     * Sets up a focused composable that records all key events, runs the given [block] against
+     * the node, and returns the recorded events.
+     */
+    private fun runWithKeyRecorder(
+        block: (androidx.compose.ui.test.SemanticsNodeInteraction) -> Unit,
+    ): List<KeyEvent> {
+        val events = mutableStateListOf<KeyEvent>()
+        runSkikoComposeUiTest {
+            val focusRequester = FocusRequester()
+            setContent {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .testTag("keyTarget")
+                        .focusRequester(focusRequester)
+                        .onPreviewKeyEvent { event ->
+                            events += event
+                            true
+                        }
+                        .focusable()
+                )
+            }
+            waitForIdle()
+            runOnUiThread { focusRequester.requestFocus() }
+            waitForIdle()
+
+            block(onNode(hasTestTag("keyTarget")))
+        }
+        return events
+    }
+}

--- a/driver-core/src/jvmTest/kotlin/io/github/jdemeulenaere/compose/driver/MultiRootTest.kt
+++ b/driver-core/src/jvmTest/kotlin/io/github/jdemeulenaere/compose/driver/MultiRootTest.kt
@@ -1,0 +1,145 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package io.github.jdemeulenaere.compose.driver
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isRoot as isRootMatcher
+import androidx.compose.ui.test.printToString
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.window.Popup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests verifying that the compose-driver multi-root handling works correctly when a Popup is
+ * displayed (which creates a second semantic root node).
+ */
+class MultiRootTest {
+
+    @Test
+    fun multipleRootsExist_whenPopupIsOpen() {
+        runSkikoComposeUiTest {
+            setContent { TestContentWithPopup() }
+            waitForIdle()
+
+            val roots = onAllNodes(isRootMatcher()).fetchSemanticsNodes()
+            assertTrue(
+                roots.size >= 2,
+                "Expected at least 2 roots when a Popup is open, but found ${roots.size}",
+            )
+        }
+    }
+
+    @Test
+    fun printAllRoots_containsBothMainAndPopupContent() {
+        runSkikoComposeUiTest {
+            setContent { TestContentWithPopup() }
+            waitForIdle()
+
+            val allRoots = onAllNodes(isRootMatcher())
+            val output = allRoots.printToString(maxDepth = Int.MAX_VALUE)
+
+            assertTrue(
+                "mainContent" in output,
+                "All-roots printToString should contain mainContent tag.\nOutput:\n$output",
+            )
+            assertTrue(
+                "popupContent" in output,
+                "All-roots printToString should contain popupContent tag.\nOutput:\n$output",
+            )
+        }
+    }
+
+    @Test
+    fun firstRoot_canBeUsedForScreenshot() {
+        runSkikoComposeUiTest {
+            setContent { TestContentWithPopup() }
+            waitForIdle()
+
+            // This is what resolveNode(null) does — get the first root via onAllNodes(isRoot())[0].
+            // It should not crash even with multiple roots.
+            val firstRoot = onAllNodes(isRootMatcher())[0]
+            val image = firstRoot.captureToImage()
+            assertTrue(image.width > 0, "Screenshot should produce a non-empty image")
+            assertTrue(image.height > 0, "Screenshot should produce a non-empty image")
+        }
+    }
+
+    @Test
+    fun nodeSelection_findsNodeInPopup() {
+        runSkikoComposeUiTest {
+            setContent { TestContentWithPopup() }
+            waitForIdle()
+
+            // onNode(hasTestTag(...)) searches across ALL roots, so it should find nodes
+            // inside the popup's root.
+            val node = onNode(hasTestTag("popupContent")).fetchSemanticsNode()
+            assertTrue(
+                node.config.any { it.key.name == "TestTag" && it.value == "popupContent" },
+                "Should find popupContent node inside popup root",
+            )
+        }
+    }
+
+    @Test
+    fun nodeSelection_findsNodeInMainContent() {
+        runSkikoComposeUiTest {
+            setContent { TestContentWithPopup() }
+            waitForIdle()
+
+            val node = onNode(hasTestTag("mainContent")).fetchSemanticsNode()
+            assertTrue(
+                node.config.any { it.key.name == "TestTag" && it.value == "mainContent" },
+                "Should find mainContent node in main root",
+            )
+        }
+    }
+
+    @Test
+    fun firstRoot_printToString_succeeds() {
+        runSkikoComposeUiTest {
+            setContent { TestContentWithPopup() }
+            waitForIdle()
+
+            // This is what /printTree?nodeTag=... does — uses onNode(matcher) which searches
+            // all roots. Without a tag, the driver uses onAllNodes(isRoot())[0].
+            val firstRoot = onAllNodes(isRootMatcher())[0]
+            val output = firstRoot.printToString()
+            assertTrue(output.isNotEmpty(), "First root printToString should produce output")
+        }
+    }
+
+    @Test
+    fun waitForIdle_withMultipleRoots_succeeds() {
+        runSkikoComposeUiTest {
+            setContent { TestContentWithPopup() }
+
+            // waitForIdle should work without crashing even with multiple roots.
+            waitForIdle()
+
+            // Verify the tree is intact.
+            val roots = onAllNodes(isRootMatcher()).fetchSemanticsNodes()
+            assertTrue(roots.isNotEmpty(), "Should have at least one root after waitForIdle")
+        }
+    }
+}
+
+@Composable
+private fun TestContentWithPopup() {
+    Box(Modifier.fillMaxSize().testTag("mainContent")) {
+        BasicText("Main content")
+        Popup {
+            Box(Modifier.testTag("popupContent")) {
+                BasicText("Popup content")
+            }
+        }
+    }
+}

--- a/driver-plugin/src/main/kotlin/io/github/jdemeulenaere/compose/driver/plugin/DriverSettingsPlugin.kt
+++ b/driver-plugin/src/main/kotlin/io/github/jdemeulenaere/compose/driver/plugin/DriverSettingsPlugin.kt
@@ -141,11 +141,7 @@ private fun addDependencies(
 private const val COMPOSABLE_PROPERTY = "compose.driver.composable"
 
 private fun driverDependency(version: String): String {
-    return if (version.endsWith("-SNAPSHOT")) {
-        "project(\":compose-driver:driver-core\")"
-    } else {
-        "\"io.github.jdemeulenaere:compose-driver:$version\""
-    }
+    return "\"io.github.jdemeulenaere:compose-driver:$version\""
 }
 
 private fun androidBuildFile(

--- a/sample/.agent/skills/compose-driver/SKILL.md
+++ b/sample/.agent/skills/compose-driver/SKILL.md
@@ -73,16 +73,44 @@ These parameters can be used on all endpoints, applying the operation to the mat
 
 ### 3. Interaction (Control)
 
-| Action            | Endpoint           | Additional parameters | Description                                                                               |
-|:------------------|:-------------------|:----------------------|:------------------------------------------------------------------------------------------|
-| **Click**         | `/click`           |                       | Performs a click on the element.                                                          |
-| **Double Click**  | `/doubleClick`     |                       | Performs a double-click.                                                                  |
-| **Long Click**    | `/longClick`       |                       | Performs a long-press.                                                                    |
-| **Input Text**    | `/textInput`       | `text` (req)          | Types text into a focused or specified text field.                                        |
-| **Replace Text**  | `/textReplacement` | `text` (req)          | Replaces the text content directly (simulates pasting/programmatic set).                  |
-| **Clear Text**    | `/textClearance`   |                       | Clears the text in a field.                                                               |
-| **Navigate Back** | `/navigateBack`    |                       | Triggers the system "Back" button event.                                                  |
-| **Scroll To**     | `/scrollTo`        |                       | Scrolls to make the element visible in the viewport, so that it can then be clicked, etc. |
+| Action            | Endpoint           | Additional parameters                                            | Description                                                                               |
+|:------------------|:-------------------|:-----------------------------------------------------------------|:------------------------------------------------------------------------------------------|
+| **Click**         | `/click`           |                                                                  | Performs a click on the element.                                                          |
+| **Double Click**  | `/doubleClick`     |                                                                  | Performs a double-click.                                                                  |
+| **Long Click**    | `/longClick`       |                                                                  | Performs a long-press.                                                                    |
+| **Input Text**    | `/textInput`       | `text` (req)                                                     | Types text into a focused or specified text field.                                        |
+| **Replace Text**  | `/textReplacement` | `text` (req)                                                     | Replaces the text content directly (simulates pasting/programmatic set).                  |
+| **Clear Text**    | `/textClearance`   |                                                                  | Clears the text in a field.                                                               |
+| **Key Event**     | `/keyEvent`        | `key` (req), `action` (opt, def: `press`), `modifiers` (opt)    | Sends a raw keyboard event. See **Key Events** section below.                             |
+| **Navigate Back** | `/navigateBack`    |                                                                  | Triggers the system "Back" button event.                                                  |
+| **Scroll To**     | `/scrollTo`        |                                                                  | Scrolls to make the element visible in the viewport, so that it can then be clicked, etc. |
+
+#### Key Events
+
+The `/keyEvent` endpoint sends raw keyboard events to a Compose UI node.
+
+**Parameters:**
+
+* `key` (required): Property name from `androidx.compose.ui.input.key.Key` (e.g., `A`, `Enter`,
+  `DirectionUp`, `ShiftLeft`, `F1`).
+* `action` (optional, default: `press`):
+    * `press` — sends key down + key up (a full key press).
+    * `down` — sends only key down (hold the key).
+    * `up` — sends only key up (release the key).
+* `modifiers` (optional): Comma-separated list of modifier key names to hold down during a `press`
+  action (e.g., `ShiftLeft`, `CtrlLeft,ShiftLeft`). Only applies when `action=press`.
+
+**Examples:**
+
+```
+GET /keyEvent?key=Enter
+GET /keyEvent?key=A&nodeTag=myTextField
+GET /keyEvent?key=A&modifiers=ShiftLeft
+GET /keyEvent?key=C&modifiers=CtrlLeft
+GET /keyEvent?key=Delete&modifiers=CtrlLeft,ShiftLeft
+GET /keyEvent?key=ShiftLeft&action=down
+GET /keyEvent?key=ShiftLeft&action=up
+```
 
 ### 4. Gestures
 
@@ -126,3 +154,11 @@ clicking).
 1. **Inspect:** `GET /printTree` -> Find the tag `target_item`.
 2. **Scroll:** `GET /scrollTo?nodeTag=target_item` -> This brings the item into the viewport.
 3. **Act:** `GET /click?nodeTag=target_item`
+
+**Scenario: Keyboard Shortcuts**
+
+1. **Focus:** `GET /click?nodeTag=editor` -> Click to focus the text editor.
+2. **Select all:** `GET /keyEvent?key=A&modifiers=CtrlLeft&nodeTag=editor`
+3. **Copy:** `GET /keyEvent?key=C&modifiers=CtrlLeft&nodeTag=editor`
+4. **Navigate:** `GET /keyEvent?key=DirectionDown&nodeTag=editor` -> Move cursor down.
+5. **Submit:** `GET /keyEvent?key=Enter&nodeTag=editor`

--- a/sample/multiplatform/src/commonMain/kotlin/io/github/jdemeulenaere/compose/driver/sample/multiplatform/MultiplatformApplication.kt
+++ b/sample/multiplatform/src/commonMain/kotlin/io/github/jdemeulenaere/compose/driver/sample/multiplatform/MultiplatformApplication.kt
@@ -3,11 +3,14 @@ package io.github.jdemeulenaere.compose.driver.sample.multiplatform
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.animateBounds
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -71,6 +74,31 @@ fun MultiplatformApplication(name: String) {
                                 .animateBounds(lookaheadScope = this@LookaheadScope),
                         ) {
                             Text("Counter: $counter")
+                        }
+
+                        var showDropdown by remember { mutableStateOf(false) }
+                        Box {
+                            Button(
+                                onClick = { showDropdown = !showDropdown },
+                                Modifier.testTag("dropdownToggle"),
+                            ) {
+                                Text("Toggle Dropdown")
+                            }
+                            DropdownMenu(
+                                expanded = showDropdown,
+                                onDismissRequest = { showDropdown = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Option 1") },
+                                    onClick = { showDropdown = false },
+                                    modifier = Modifier.testTag("dropdownOption1"),
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("Option 2") },
+                                    onClick = { showDropdown = false },
+                                    modifier = Modifier.testTag("dropdownOption2"),
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
> [!IMPORTANT]
> This is part of a stacked PR chain. Please review and merge in order:
> 1. #2 — `/keyEvent` endpoint
> 2. **#3** (this PR) — Multi-root node handling
> 3. #4 — Video recording

## Summary

- Fix crash on `/printTree`, `/screenshot`, and other endpoints when a Compose Popup is open (which creates a second semantic root node)
- `/printTree` with no selector now prints **all** root nodes instead of asserting exactly one
- `/screenshot` and other no-selector endpoints safely target the first root via `onAllNodes(isRoot())[0]`
- Added 7 unit tests covering multi-root behavior with `Popup`
- Added a `DropdownMenu` to the sample app for manual/IRL testing

## Test plan

- [x] All 7 `MultiRootTest` tests pass (`./gradlew :driver-core:jvmTest`)
- [x] Sample app compiles and runs with the new dropdown
- [x] Manually verified: opening the dropdown and hitting `/printTree`, `/screenshot` no longer crashes